### PR TITLE
add average of foldable of fractional

### DIFF
--- a/src/main/scala/scaloi/misc/Monoids.scala
+++ b/src/main/scala/scaloi/misc/Monoids.scala
@@ -85,4 +85,9 @@ object Monoids {
     override def zero: Map[K, V]                                    = Map.empty
     override def append(f1: Map[K, V], f2: => Map[K, V]): Map[K, V] = f1 ++ f2
   }
+
+  import scala.Numeric.Implicits._
+
+  /** An additive [[scalaz.Monoid]] for a [[scala.Numeric]]. */
+  implicit def numericMonoid[A: Numeric]: Monoid[A] = Monoid.instance((a0, a1) => a0 + a1, Numeric[A].zero)
 }

--- a/src/main/scala/scaloi/syntax/FoldableOps.scala
+++ b/src/main/scala/scaloi/syntax/FoldableOps.scala
@@ -58,6 +58,12 @@ final class FoldableOps[F[_], A](private val self: F[A]) extends AnyVal {
   @inline final def hyperList[B](implicit ev: Foldable[F], x: A <:< F[B]): List[List[B]] =
     Foldable[F].toList(self).map(a => Foldable[F].toList(x(a)))
 
+  import misc.Monoids.numericMonoid
+  import scala.Fractional.Implicits._
+
+  /** Compute the average of an `F` of a [[scala.Fractional]] type. An empty `F` has a NaN or fatal average. This is fine. */
+  @inline def average(implicit F: Foldable[F], A: Fractional[A]): A =
+    F.suml(self) / A.fromInt(F.length(self))
 }
 
 /**

--- a/src/test/scala/scaloi/misc/MonoidsTest.scala
+++ b/src/test/scala/scaloi/misc/MonoidsTest.scala
@@ -49,6 +49,14 @@ class MonoidsTest extends AnyFlatSpec with OptionValues with Matchers {
 
     Map(1 -> 2, 2 -> 3) |+| Map(2 -> 4, 4 -> 5) shouldEqual Map(1 -> 2, 2 -> 4, 4 -> 5)
   }
+
+  it should "monoid numerics" in {
+    import Monoids.numericMonoid
+    import scalaz.syntax.monoid._
+
+    1 |+| 2 shouldEqual 3
+    1.0 |+| 2.0 shouldEqual 3.0
+  }
 }
 
 object MonoidsTest {

--- a/src/test/scala/scaloi/syntax/FoldableOpsTest.scala
+++ b/src/test/scala/scaloi/syntax/FoldableOpsTest.scala
@@ -51,4 +51,12 @@ class FoldableOpsTest extends AnyFlatSpec with OptionValues with Matchers {
   it should "hyper list" in {
     EphemeralStream(EphemeralStream(1, 2), EphemeralStream(3, 4)).hyperList shouldEqual List(List(1, 2), List(3, 4))
   }
+
+  it should "average" in {
+    import scalaz.std.list._
+
+    List.empty[Float].average.isNaN shouldBe true
+    List(1.0).average shouldEqual 1.0
+    List(0.0, 1.0, 3.0, 4.0).average shouldEqual 2.0
+  }
 }


### PR DESCRIPTION
This elegant solution lets me replace such hideous code as:
```
points.sum / points.size
```
with
```
import scalaz.std.list._
import scaloi.syntax.foldable._
points.average
```